### PR TITLE
Remove scientific notation and decimal

### DIFF
--- a/js/site.js
+++ b/js/site.js
@@ -176,14 +176,11 @@ function generate3WComponent(config, data, geom) {
     var formatComma = d3.format(',');
 
     ooscNumber.group(gp)
-        .formatNumber(d3.format(".3s"))
+        .formatNumber(d3.format(""))
         .valueAccessor(getTotalOosc);
-    //.formatNumber();
 
     countriesNumber.group(gp)
-
-        .formatNumber(d3.format(".3s"))
-
+        .formatNumber(d3.format(""))
         .valueAccessor(getCountries);
 
     dc.dataCount('#count-info')


### PR DESCRIPTION
Hello,

Je viens d'avoir Javier, il veut que le nombre de pays soit un entier et pas avec une décimale et pour le nombre d'enfant targeted, il veut le chiffre exact pas en scientifique. J'ai juste changer deux lignes au formatage dans ton code.

Amitié,